### PR TITLE
Switch to using 2 engine workers

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -56,7 +56,7 @@ services:
 
   engine:
     image: projectlovelace/lovelace-engine
-    command: gunicorn --worker-tmp-dir /dev/shm --workers 1 --log-level debug --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
+    command: gunicorn --worker-tmp-dir /dev/shm --workers 2 --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     expose:

--- a/docker-compose.staging.yml
+++ b/docker-compose.staging.yml
@@ -56,7 +56,7 @@ services:
 
   engine:
     image: projectlovelace/lovelace-engine
-    command: gunicorn --worker-tmp-dir /dev/shm --workers 1 --log-level debug --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
+    command: gunicorn --worker-tmp-dir /dev/shm --workers 2 --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     expose:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
 
   engine:
     image: projectlovelace/lovelace-engine
-    command: gunicorn --worker-tmp-dir /dev/shm --workers 1 --log-level debug --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
+    command: gunicorn --worker-tmp-dir /dev/shm --workers 2 --log-level debug --timeout 600 --preload --reload --bind 0.0.0.0:14714 engine.api:app
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
     expose:


### PR DESCRIPTION
By default we've been using 1 gunicorn worker for the lovelace-engine. Would be good to bump it up to 2 so people can still submit solutions when one engine is busy.