### PR TITLE
Fixed `donated_blood` variable consistency

### DIFF
--- a/src/problems/templates/problems/blood-types.html
+++ b/src/problems/templates/problems/blood-types.html
@@ -58,7 +58,7 @@ True if the person can be saved, and false otherwise.
 {% endblock %}
 
 {% block function_signature %}
-survive(blood_type, available_blood_types)
+survive(blood_type, donated_blood)
 {% endblock %}
 
 {% block notes_and_references %}


### PR DESCRIPTION
The functions in the code editor for the "Blood types" problem, contain the arguments: `blood_type` and `donated_blood` whereas, the function description contains the arguments, `blood_type` and `available_blood_types`. 

This PR fixes this inconsistency.