### PR TITLE
Wraps long lines in example codes

### DIFF
--- a/src/problems/templates/problems/blood-types.html
+++ b/src/problems/templates/problems/blood-types.html
@@ -42,7 +42,7 @@ True if the person can be saved, and false otherwise.
   <div class="message-header">
     <p>Example 1</p>
   </div>
-  <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre;"><b>Input blood type</b>: "B+"
+  <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre-wrap;"><b>Input blood type</b>: "B+"
 <b>Input list of available blood types</b>: ["A-", "B+", "AB+", "O+", "B+", "B-"]
 <b>Output survivability</b>: True</div>
 </article>
@@ -51,7 +51,7 @@ True if the person can be saved, and false otherwise.
   <div class="message-header">
     <p>Example 2</p>
   </div>
-  <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre;"><b>Input blood type</b>: "AB-"
+  <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre-wrap;"><b>Input blood type</b>: "AB-"
 <b>Input list of available blood types</b>: ["O+", "AB+"]
 <b>Output survivability</b>: False</div>
 </article>

--- a/src/problems/templates/problems/colorful-resistors.html
+++ b/src/problems/templates/problems/colorful-resistors.html
@@ -50,7 +50,7 @@
     <div class="message-header">
       <p>Example 1 (four-band resistor)</p>
     </div>
-    <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre;"><b>Input resistor band colors</b>: ["green", "blue", "yellow", "gold"]
+    <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre-wrap;"><b>Input resistor band colors</b>: ["green", "blue", "yellow", "gold"]
 <b>Output nominal resistance</b>: 560000
 <b>Output minimum resistance</b>: 532000
 <b>Output maximum resistance</b>: 588000
@@ -59,7 +59,7 @@
     <div class="message-header">
       <p>Example 2 (five-band resistor)</p>
     </div>
-    <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre;"><b>Input resistor band colors</b>: ["red", "orange", "violet", "black", "brown"]
+    <div class="message-body" style="font-family: monospace; text-align: justify; word-wrap: break-word; white-space:pre-wrap;"><b>Input resistor band colors</b>: ["red", "orange", "violet", "black", "brown"]
 <b>Output nominal resistance</b>: 237.00
 <b>Output minimum resistance</b>: 234.63
 <b>Output maximum resistance</b>: 239.37


### PR DESCRIPTION
This PR is a fix for #150 where if the line is long enough, gets wrapped to the next line. Thanks to @Vismai-Khanderao for the fix-suggestion.